### PR TITLE
Override `stroke-dasharray` attribute in XY chart if option has `dataLineDashes`

### DIFF
--- a/src/XY.js
+++ b/src/XY.js
@@ -150,6 +150,7 @@ class XY {
         .attr('d', (d) => theLine(d.data))
         .attr('fill', 'none')
         .attr('stroke', (d, i) => (this.options.dataColors ? this.options.dataColors[i] : colors[i]))
+        .attr('stroke-dasharray', (d, i) => (this.options.dataLineDashes ? this.options.dataLineDashes[i] : ''))
         .attr('filter', this.filter);
     }
 


### PR DESCRIPTION
this pr is just proposal.
I need this option for personal reason. similar option in line & xy charts would help to make the chart