### PR TITLE
Fixed typo in legendPosition documentation for Line Chart

### DIFF
--- a/docs/04-line.md
+++ b/docs/04-line.md
@@ -41,7 +41,7 @@ const lineChart = new chartXkcd.Line(svg, {
 - `legendPosition`: specify where you want to place the legend. (default `chartXkcd.config.positionType.upLeft`)
   Possible values:
     - up left: `chart.Xkcd.positionType.upLeft`
-    - up right: `chart.Xkcd.positionType.upLeft`
+    - up right: `chart.Xkcd.positionType.upRight`
 - `dataColors`: array of colors for different datasets
 - `fontFamily`: customize font family used in the chart
 - `unxkcdify`: disable xkcd effect (default `false`)


### PR DESCRIPTION
legendPosition can be set to 'up right', in the settings it was chart.Xkcd.positionType.upLeft


