### PR TITLE
fix(tooltip): Position tooltip after title in the dom

### DIFF
--- a/src/Bar.js
+++ b/src/Bar.js
@@ -80,6 +80,8 @@ class Bar {
     if (this.xLabel) addLabels.xLabel(this.svgEl, this.xLabel);
     if (this.yLabel) addLabels.yLabel(this.svgEl, this.yLabel);
 
+    this.tooltip.render();
+
     const xScale = scaleBand()
       .range([0, this.width])
       .domain(this.data.labels)

--- a/src/Line.js
+++ b/src/Line.js
@@ -82,6 +82,8 @@ class Line {
     if (this.xLabel) addLabels.xLabel(this.svgEl, this.xLabel);
     if (this.yLabel) addLabels.yLabel(this.svgEl, this.yLabel);
 
+    this.tooltip.render();
+
     const xScale = scalePoint()
       .domain(this.data.labels)
       .range([0, this.width]);

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -75,6 +75,8 @@ class Pie {
         .text(this.title);
     }
 
+    this.tooltip.render();
+
     const radius = Math.min(this.width, this.height) / 2 - margin;
 
     const thePie = pie();

--- a/src/Radar.js
+++ b/src/Radar.js
@@ -78,6 +78,8 @@ class Radar {
         .text(this.title);
     }
 
+    this.tooltip.render();
+
     const dotInitSize = 3.5 * (this.options.dotSize || 1);
     const dotHoverSize = 6 * (this.options.dotSize || 1);
     const dataColors = this.options.dataColors || colors;

--- a/src/XY.js
+++ b/src/XY.js
@@ -86,6 +86,8 @@ class XY {
     if (this.xLabel) addLabels.xLabel(this.svgEl, this.xLabel);
     if (this.yLabel) addLabels.yLabel(this.svgEl, this.yLabel);
 
+    this.tooltip.render();
+
     if (this.options.timeFormat) {
       this.data.datasets.forEach((dataset) => {
         dataset.data.forEach((d) => {

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -26,12 +26,15 @@ class Tooltip {
   constructor({
     parent, title, items, position, unxkcdify,
   }) {
+    this.parent = parent;
     this.title = title;
     this.items = items;
     this.position = position;
     this.filter = !unxkcdify ? 'url(#xkcdify)' : null;
+  }
 
-    this.svg = parent.append('svg')
+  render() {
+    this.svg = this.parent.append('svg')
       .attr('x', this._getUpLeftX())
       .attr('y', this._getUpLeftY())
       .style('visibility', 'hidden');
@@ -54,9 +57,9 @@ class Tooltip {
       .style('font-weight', 'bold')
       .attr('x', 15)
       .attr('y', 25)
-      .text(title);
+      .text(this.title);
 
-    this.tipItems = items.map((item, i) => {
+    this.tipItems = this.items.map((item, i) => {
       const g = this.svg.append('g');
       g.append('rect')
         .style('fill', item.color)


### PR DESCRIPTION
**Related issue**

Fix #33

**Screenshot before and after this change**

## Before
<img width="391" alt="Screen Shot 2019-09-11 at 1 42 55 PM" src="https://user-images.githubusercontent.com/5314713/64725396-1e4e2280-d49a-11e9-9727-e2a2c9ac438f.png">
<img width="395" alt="Screen Shot 2019-09-11 at 1 42 50 PM" src="https://user-images.githubusercontent.com/5314713/64725398-1e4e2280-d49a-11e9-9d1a-ce2307aa6954.png">

## After
<img width="387" alt="Screen Shot 2019-09-11 at 1 42 23 PM" src="https://user-images.githubusercontent.com/5314713/64725415-26a65d80-d49a-11e9-8190-87c404dc5902.png">
<img width="366" alt="Screen Shot 2019-09-11 at 1 42 11 PM" src="https://user-images.githubusercontent.com/5314713/64725416-26a65d80-d49a-11e9-952a-b8f2661bc1ac.png">


