### PR TITLE
Line chart: fixed the check dataColors options array for emptyness

### DIFF
--- a/src/Line.js
+++ b/src/Line.js
@@ -12,7 +12,10 @@ import addLegend from './utils/addLegend';
 import addFont from './utils/addFont';
 import addFilter from './utils/addFilter';
 import colors from './utils/colors';
+import arrayUtils from './utils/arrayUtils';
 import config from './config';
+
+const { isEmptyArray } = arrayUtils;
 
 const margin = {
   top: 50, right: 30, bottom: 50, left: 50,
@@ -127,7 +130,7 @@ class Line {
       .attr('class', 'xkcd-chart-line')
       .attr('d', (d) => theLine(d.data))
       .attr('fill', 'none')
-      .attr('stroke', (d, i) => (this.options.dataColors
+      .attr('stroke', (d, i) => (!isEmptyArray(this.options.dataColors)
         ? this.options.dataColors[i]
         : colors[i]))
       .attr('filter', this.filter);
@@ -145,8 +148,8 @@ class Line {
 
     const circles = this.data.datasets.map((dataset, i) => graphPart
       .append('circle')
-      .style('stroke', this.options.dataColors ? this.options.dataColors[i] : colors[i])
-      .style('fill', this.options.dataColors ? this.options.dataColors[i] : colors[i])
+      .style('stroke', !isEmptyArray(this.options.dataColors) ? this.options.dataColors[i] : colors[i])
+      .style('fill', !isEmptyArray(this.options.dataColors) ? this.options.dataColors[i] : colors[i])
       .attr('r', 3.5)
       .style('visibility', 'hidden'));
 
@@ -187,7 +190,7 @@ class Line {
         });
 
         const tooltipItems = this.data.datasets.map((dataset, j) => ({
-          color: this.options.dataColors ? this.options.dataColors[j] : colors[j],
+          color: !isEmptyArray(this.options.dataColors) ? this.options.dataColors[j] : colors[j],
           text: `${this.data.datasets[j].label || ''}: ${this.data.datasets[j].data[mostNearLabelIndex]}`,
         }));
 
@@ -214,7 +217,7 @@ class Line {
     // Legend
     const legendItems = this.data.datasets
       .map((dataset, i) => ({
-        color: this.options.dataColors ? this.options.dataColors[i] : colors[i],
+        color: !isEmptyArray(this.options.dataColors) ? this.options.dataColors[i] : colors[i],
         text: dataset.label,
       }));
 

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -120,7 +120,7 @@ class Tooltip {
 
     return g;
   }
-  
+
   _getBackgroundWidth() {
     const maxItemLength = this.items.reduce(
       (pre, cur) => (pre > cur.text.length ? pre : cur.text.length), 0,

--- a/src/utils/arrayUtils.js
+++ b/src/utils/arrayUtils.js
@@ -1,0 +1,10 @@
+
+const isEmptyArray = (data) => {
+  if (!data) {
+    return true;
+  }
+
+  return !(Array.isArray(data) && data.length);
+};
+
+export default { isEmptyArray };


### PR DESCRIPTION
**Related issue**

Fix #42 

Due to `options` wasn't passed in `Line` object, it was getting `options.dataColors` as the `[ ]` empty due to which it wasn't getting any colors to plot

**Screenshot before and after this change**
I was using `index.html` charts example to test things out, so i had used the empty `options` for `Line` chart to replicate

## before
![image](https://user-images.githubusercontent.com/1594650/66720500-0fe98280-ee1b-11e9-8263-1b97a7a66bda.png)


## after

![image](https://user-images.githubusercontent.com/1594650/66720522-4aebb600-ee1b-11e9-9d25-c955a3e61a88.png)

