### PR TITLE
 Tooltip: fixed Math.max may return NaN with title is number

### DIFF
--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -141,7 +141,7 @@ class Tooltip {
     const maxItemLength = this.items.reduce(
       (pre, cur) => (pre > cur.text.length ? pre : cur.text.length), 0,
     );
-    const maxLength = Math.max(maxItemLength, this.title.length);
+    const maxLength = this.title ? Math.max(maxItemLength, this.title.length) : maxItemLength;
 
     return maxLength * 7.4 + 25;
   }

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -76,7 +76,7 @@ class Tooltip {
   // update tooltip position / content
   update({ title, items, position }) {
     if (title && title !== this.title) {
-      this.title = title;
+      this.title = `${title}`;
       this.tipTitle.text(title);
     }
 


### PR DESCRIPTION
**Related issue**

Fix #60


