### PR TITLE
Standardise on starting the y-axis from zero

### DIFF
--- a/src/Line.js
+++ b/src/Line.js
@@ -97,7 +97,7 @@ class Line {
       .reduce((pre, cur) => pre.concat(cur.data), []);
 
     const yScale = scaleLinear()
-      .domain([Math.min(...allData), Math.max(...allData)])
+      .domain([0, Math.max(...allData)])
       .range([this.height, 0]);
 
     const graphPart = this.chart.append('g')

--- a/src/XY.js
+++ b/src/XY.js
@@ -121,7 +121,7 @@ class XY {
     }
 
     const yScale = scaleLinear()
-      .domain([Math.min(...allDataY), Math.max(...allDataY)])
+      .domain([0, Math.max(...allDataY)])
       .range([this.height, 0]);
 
     const graphPart = this.chart.append('g')


### PR DESCRIPTION
This reduces the surprise factor of this library by ensuring that the y-axis on both line and XY
charts starts from zero to match that of bar charts.

This shows no visible change on the current example line/XY graphs because they all have values very close to zero already. If you think it would be beneficial to have an additional example to show this say and I will add one.

This will change the behaviour of existing line/XY graphs and so do say if you would prefer that this was a configuration option and I can extend it to be.

Finally this will not play well with having y values which are less than zero. None of your examples show this so I am not sure how much this is an issue. Do let me know if you want this covered.


