### PR TITLE
fix: add legend support to Bar chart

### DIFF
--- a/src/Bar.js
+++ b/src/Bar.js
@@ -5,6 +5,7 @@ import scaleLinear from 'd3-scale/src/linear';
 
 import addAxis from './utils/addAxis';
 import addLabels from './utils/addLabels';
+import addLegend from './utils/addLegend';
 import Tooltip from './components/Tooltip';
 import addFont from './utils/addFont';
 import addFilter from './utils/addFilter';
@@ -26,6 +27,8 @@ class Bar {
       fontFamily: 'xkcd',
       strokeColor: 'black',
       backgroundColor: 'white',
+      showLegend: true,
+      legendPosition: config.positionType.downRight,
       ...options,
     };
     if (title) {
@@ -168,6 +171,24 @@ class Bar {
           },
         });
       });
+
+    // Add legend support
+    if (this.options.showLegend) {
+      const legendItems = this.data.datasets.map((dataset, j) => ({
+        color: this.options.dataColors[j],
+        text: `${dataset.label || ''}`,
+      }));
+
+      addLegend(graphPart, {
+        items: legendItems,
+        position: this.options.legendPosition,
+        unxkcdify: this.options.unxkcdify,
+        parentWidth: this.width,
+        parentHeight: this.height,
+        strokeColor: this.options.strokeColor,
+        backgroundColor: this.options.backgroundColor,
+      });
+    }
   }
 
   // TODO: update chart


### PR DESCRIPTION
## Problem
Bar chart component was missing legend support, while other chart types (Line, Pie, Radar, StackedBar, XY) all have it. This causes legends to not show up for bar charts.

## Solution
- Import the existing `addLegend` utility
- Add `showLegend` (default: true) and `legendPosition` (default: downRight) options
- Render legend with dataset labels and colors, matching the pattern used in other chart types

## Changes
- Modified `src/Bar.js`:
  - Added import for `addLegend` utility
  - Added legend options to constructor defaults
  - Added legend rendering logic at the end of render() method

## Testing
The legend should now appear on bar charts when `showLegend` is true (default).

Fixes #101