### PR TITLE
Add combined chart type

### DIFF
--- a/docs/10-combined.md
+++ b/docs/10-combined.md
@@ -1,0 +1,49 @@
+---
+title: Combined chart
+---
+
+A combined chart displays bar datasets and line datasets in the same chart. It is useful when related series share the same labels and y axis but need different visual treatments.
+
+## JS part
+
+```js
+const combinedChart = new chartXkcd.Combined(svg, {
+  title: 'Monthly visitors and signups', // optional
+  xLabel: 'Month', // optional
+  yLabel: 'Count', // optional
+  data: {
+    labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+    datasets: [{
+      label: 'Visitors',
+      type: 'bar',
+      data: [120, 180, 150, 220, 260, 310],
+    }, {
+      label: 'Signups',
+      type: 'line',
+      data: [15, 20, 18, 32, 44, 56],
+    }],
+  },
+  options: { // optional
+    yTickCount: 3,
+    legendPosition: chartXkcd.config.positionType.upLeft
+  }
+});
+```
+
+Datasets with `type: 'bar'` render as bars. Datasets with `type: 'line'` render as lines.
+
+## Customize chart by defining options
+
+- `yTickCount`: customize tick numbers you want to see on the y axis (default `3`)
+- `showLegend`: display legend near chart (default `true`)
+- `legendPosition`: specify where you want to place the legend. (default `chartXkcd.config.positionType.upLeft`)
+  Possible values:
+    - up left: `chartXkcd.config.positionType.upLeft`
+    - up right: `chartXkcd.config.positionType.upRight`
+    - bottom left: `chartXkcd.config.positionType.downLeft`
+    - bottom right: `chartXkcd.config.positionType.downRight`
+- `dataColors`: array of colors for different datasets
+- `fontFamily`: customize font family used in the chart
+- `unxkcdify`: disable xkcd effect (default `false`)
+- `strokeColor`: stroke colors (default `black`)
+- `backgroundColor`: color for BG (default `white`)

--- a/examples/example.html
+++ b/examples/example.html
@@ -11,6 +11,7 @@
     <div style="width: 400px; height: 300px; display: inline-block;"><svg class="stacked-bar-chart"></svg></div>
     <div style="width: 400px; height: 300px; display: inline-block;"><svg class="pie-chart"></svg></div>
     <div style="width: 400px; height: 300px; display: inline-block;"><svg class="line-chart"></svg></div>
+    <div style="width: 400px; height: 300px; display: inline-block;"><svg class="combined-chart"></svg></div>
     <div style="width: 400px; height: 300px; display: inline-block;"><svg class="xyline-chart"></svg></div>
     <div style="width: 400px; height: 300px; display: inline-block;"><svg class="xyline-chart2"></svg></div>
     <div style="width: 400px; height: 300px; display: inline-block;"><svg class="radar-chart"></svg></div>

--- a/examples/index.js
+++ b/examples/index.js
@@ -90,6 +90,28 @@ new chartXkcd.Line(svgLine, {
   },
 });
 
+const svgCombined = document.querySelector('.combined-chart');
+new chartXkcd.Combined(svgCombined, {
+  title: 'Monthly visitors and signups',
+  xLabel: 'Month',
+  yLabel: 'Count',
+  data: {
+    labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+    datasets: [{
+      label: 'Visitors',
+      type: 'bar',
+      data: [120, 180, 150, 220, 260, 310],
+    }, {
+      label: 'Signups',
+      type: 'line',
+      data: [15, 20, 18, 32, 44, 56],
+    }],
+  },
+  options: {
+    legendPosition: chartXkcd.config.positionType.upLeft,
+  },
+});
+
 const svgXY = document.querySelector('.xyline-chart');
 new chartXkcd.XY(svgXY, {
   title: 'stars',

--- a/src/Combined.js
+++ b/src/Combined.js
@@ -1,0 +1,283 @@
+import line from 'd3-shape/src/line';
+import { monotoneX } from 'd3-shape/src/curve/monotone';
+import select from 'd3-selection/src/select';
+import mouse from 'd3-selection/src/mouse';
+import scaleBand from 'd3-scale/src/band';
+import scaleLinear from 'd3-scale/src/linear';
+
+import addAxis from './utils/addAxis';
+import addLabels from './utils/addLabels';
+import Tooltip from './components/Tooltip';
+import addLegend from './utils/addLegend';
+import addFont from './utils/addFont';
+import addFilter from './utils/addFilter';
+import colors from './utils/colors';
+import config from './config';
+
+const margin = {
+  top: 50, right: 30, bottom: 50, left: 50,
+};
+
+const getTooltipPositionType = (tipX, tipY, width, height) => {
+  if (tipX > width / 2 && tipY < height / 2) {
+    return config.positionType.downLeft;
+  }
+  if (tipX > width / 2 && tipY > height / 2) {
+    return config.positionType.upLeft;
+  }
+  if (tipX < width / 2 && tipY > height / 2) {
+    return config.positionType.upRight;
+  }
+  return config.positionType.downRight;
+};
+
+class Combined {
+  constructor(svg, {
+    title, xLabel, yLabel, data: { labels, datasets }, options,
+  }) {
+    this.options = {
+      unxkcdify: false,
+      yTickCount: 3,
+      legendPosition: config.positionType.upLeft,
+      dataColors: colors,
+      fontFamily: 'xkcd',
+      strokeColor: 'black',
+      backgroundColor: 'white',
+      showLegend: true,
+      ...options,
+    };
+    if (title) {
+      this.title = title;
+      margin.top = 60;
+    }
+    if (xLabel) {
+      this.xLabel = xLabel;
+      margin.bottom = 50;
+    }
+    if (yLabel) {
+      this.yLabel = yLabel;
+      margin.left = 70;
+    }
+    this.data = {
+      labels,
+      datasets,
+    };
+    this.filter = 'url(#xkcdify)';
+    this.fontFamily = this.options.fontFamily || 'xkcd';
+    if (this.options.unxkcdify) {
+      this.filter = null;
+      this.fontFamily = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
+    }
+
+    this.svgEl = select(svg)
+      .style('stroke-width', '3')
+      .style('font-family', this.fontFamily)
+      .style('background', this.options.backgroundColor)
+      .attr('width', svg.parentElement.clientWidth)
+      .attr('height', Math.min((svg.parentElement.clientWidth * 2) / 3, window.innerHeight));
+    this.svgEl.selectAll('*').remove();
+
+    this.chart = this.svgEl.append('g')
+      .attr('transform',
+        `translate(${margin.left},${margin.top})`);
+    this.width = this.svgEl.attr('width') - margin.left - margin.right;
+    this.height = this.svgEl.attr('height') - margin.top - margin.bottom;
+
+    addFont(this.svgEl);
+    addFilter(this.svgEl);
+    this.render();
+  }
+
+  render() {
+    if (this.title) addLabels.title(this.svgEl, this.title, this.options.strokeColor);
+    if (this.xLabel) addLabels.xLabel(this.svgEl, this.xLabel, this.options.strokeColor);
+    if (this.yLabel) addLabels.yLabel(this.svgEl, this.yLabel, this.options.strokeColor);
+
+    const datasets = this.data.datasets.map((dataset, datasetIndex) => ({
+      ...dataset,
+      datasetIndex,
+      type: dataset.type || 'line',
+    }));
+    const barDatasets = datasets.filter((dataset) => dataset.type === 'bar');
+    const lineDatasets = datasets.filter((dataset) => dataset.type !== 'bar');
+
+    const tooltip = new Tooltip({
+      parent: this.svgEl,
+      title: '',
+      items: datasets.map((dataset) => ({
+        color: this.options.dataColors[dataset.datasetIndex],
+        text: dataset.label,
+      })),
+      position: { x: 60, y: 60, type: config.positionType.downRight },
+      unxkcdify: this.options.unxkcdify,
+      backgroundColor: this.options.backgroundColor,
+      strokeColor: this.options.strokeColor,
+    });
+
+    const xScale = scaleBand()
+      .range([0, this.width])
+      .domain(this.data.labels)
+      .padding(0.4);
+
+    const allData = datasets
+      .reduce((pre, cur) => pre.concat(cur.data), []);
+
+    const yScale = scaleLinear()
+      .domain([Math.min(0, ...allData), Math.max(...allData)])
+      .range([this.height, 0]);
+
+    const graphPart = this.chart.append('g')
+      .attr('pointer-events', 'all');
+
+    addAxis.xAxis(graphPart, {
+      xScale,
+      tickCount: 3,
+      moveDown: this.height,
+      fontFamily: this.fontFamily,
+      unxkcdify: this.options.unxkcdify,
+      stroke: this.options.strokeColor,
+    });
+    addAxis.yAxis(graphPart, {
+      yScale,
+      tickCount: this.options.yTickCount || 3,
+      fontFamily: this.fontFamily,
+      unxkcdify: this.options.unxkcdify,
+      stroke: this.options.strokeColor,
+    });
+
+    const zeroY = yScale(0);
+    const barWidth = barDatasets.length
+      ? xScale.bandwidth() / barDatasets.length
+      : xScale.bandwidth();
+
+    barDatasets.forEach((dataset, datasetOrder) => {
+      const barData = dataset.data.map((value, labelIndex) => ({
+        value,
+        labelIndex,
+      }));
+
+      graphPart.selectAll(`.xkcd-chart-combined-bar-${datasetOrder}`)
+        .data(barData)
+        .enter()
+        .append('rect')
+        .attr('class', `xkcd-chart-combined-bar xkcd-chart-combined-bar-${datasetOrder}`)
+        .attr('x', (d) => xScale(this.data.labels[d.labelIndex]) + barWidth * datasetOrder)
+        .attr('width', barWidth)
+        .attr('y', (d) => yScale(Math.max(0, d.value)))
+        .attr('height', (d) => Math.abs(yScale(d.value) - zeroY))
+        .attr('fill', this.options.dataColors[dataset.datasetIndex])
+        .attr('pointer-events', 'all')
+        .attr('stroke', this.options.strokeColor)
+        .attr('stroke-width', 3)
+        .attr('rx', 2)
+        .attr('filter', this.filter);
+    });
+
+    const theLine = line()
+      .x((d, i) => xScale(this.data.labels[i]) + xScale.bandwidth() / 2)
+      .y((d) => yScale(d))
+      .curve(monotoneX);
+
+    graphPart.selectAll('.xkcd-chart-combined-line')
+      .data(lineDatasets)
+      .enter()
+      .append('path')
+      .attr('class', 'xkcd-chart-combined-line')
+      .attr('d', (d) => theLine(d.data))
+      .attr('fill', 'none')
+      .attr('stroke', (d) => this.options.dataColors[d.datasetIndex])
+      .attr('filter', this.filter);
+
+    const verticalLine = graphPart.append('line')
+      .attr('x1', 30)
+      .attr('y1', 0)
+      .attr('x2', 30)
+      .attr('y2', this.height)
+      .attr('stroke', '#aaa')
+      .attr('stroke-width', 1.5)
+      .attr('stroke-dasharray', '7,7')
+      .style('visibility', 'hidden');
+
+    const circles = lineDatasets.map((dataset) => graphPart
+      .append('circle')
+      .style('stroke', this.options.dataColors[dataset.datasetIndex])
+      .style('fill', this.options.dataColors[dataset.datasetIndex])
+      .attr('r', 3.5)
+      .style('visibility', 'hidden'));
+
+    graphPart.append('rect')
+      .attr('width', this.width)
+      .attr('height', this.height)
+      .attr('fill', 'none')
+      .on('mouseover', () => {
+        circles.forEach((circle) => circle.style('visibility', 'visible'));
+        verticalLine.style('visibility', 'visible');
+        tooltip.show();
+      })
+      .on('mouseout', () => {
+        circles.forEach((circle) => circle.style('visibility', 'hidden'));
+        verticalLine.style('visibility', 'hidden');
+        tooltip.hide();
+      })
+      .on('mousemove', (d, i, nodes) => {
+        const mouseX = mouse(nodes[i])[0];
+        const tipX = mouseX + margin.left + 10;
+        const tipY = mouse(nodes[i])[1] + margin.top + 10;
+
+        const labelXs = this.data.labels.map(
+          (label) => xScale(label) + xScale.bandwidth() / 2,
+        );
+        const mouseLabelDistances = labelXs.map((labelX) => Math.abs(labelX - mouseX));
+        const mostNearLabelIndex = mouseLabelDistances.indexOf(Math.min(...mouseLabelDistances));
+
+        verticalLine
+          .attr('x1', xScale(this.data.labels[mostNearLabelIndex]) + xScale.bandwidth() / 2)
+          .attr('x2', xScale(this.data.labels[mostNearLabelIndex]) + xScale.bandwidth() / 2);
+
+        lineDatasets.forEach((dataset, j) => {
+          circles[j]
+            .style('visibility', 'visible')
+            .attr('cx', xScale(this.data.labels[mostNearLabelIndex]) + xScale.bandwidth() / 2)
+            .attr('cy', yScale(dataset.data[mostNearLabelIndex]));
+        });
+
+        const tooltipItems = datasets.map((dataset) => ({
+          color: this.options.dataColors[dataset.datasetIndex],
+          text: `${dataset.label || ''}: ${dataset.data[mostNearLabelIndex]}`,
+        }));
+
+        tooltip.update({
+          title: this.data.labels[mostNearLabelIndex],
+          items: tooltipItems,
+          position: {
+            x: tipX,
+            y: tipY,
+            type: getTooltipPositionType(tipX, tipY, this.width, this.height),
+          },
+        });
+      });
+
+    if (this.options.showLegend) {
+      const legendItems = datasets.map((dataset) => ({
+        color: this.options.dataColors[dataset.datasetIndex],
+        text: dataset.label,
+      }));
+
+      addLegend(graphPart, {
+        items: legendItems,
+        position: this.options.legendPosition,
+        unxkcdify: this.options.unxkcdify,
+        parentWidth: this.width,
+        parentHeight: this.height,
+        backgroundColor: this.options.backgroundColor,
+        strokeColor: this.options.strokeColor,
+      });
+    }
+  }
+
+  // TODO: update chart
+  update() {
+  }
+}
+
+export default Combined;

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,11 @@ import Bar from './Bar';
 import StackedBar from './StackedBar';
 import Pie from './Pie';
 import Line from './Line';
+import Combined from './Combined';
 import XY from './XY';
 import Radar from './Radar';
 import config from './config';
 
 module.exports = {
-  config, Bar, StackedBar, Pie, Line, XY, Radar,
+  config, Bar, StackedBar, Pie, Line, Combined, XY, Radar,
 };

--- a/src/utils/addLegend.js
+++ b/src/utils/addLegend.js
@@ -1,6 +1,6 @@
 import config from '../config';
 
-export default async function addLegend(parent, {
+export default function addLegend(parent, {
   items, position, unxkcdify, parentWidth, parentHeight, strokeColor, backgroundColor,
 }) {
   const filter = !unxkcdify ? 'url(#xkcdify)' : null;
@@ -29,43 +29,43 @@ export default async function addLegend(parent, {
   });
 
   // wait for textLayer to render, a bit wired
-  await new Promise(resolve => setTimeout(resolve, 10))
+  setTimeout(() => {
+    const bbox = textLayer.node().getBBox();
+    const backgroundWidth = bbox.width + 15;
+    const backgroundHeight = bbox.height + 10;
 
-  const bbox = textLayer.node().getBBox();
-  const backgroundWidth = bbox.width + 15;
-  const backgroundHeight = bbox.height + 10;
+    let legendX = 0;
+    let legendY = 0;
+    if (
+      position === config.positionType.downLeft
+      || position === config.positionType.downRight
+    ) {
+      legendY = parentHeight - backgroundHeight - 13;
+    }
+    if (
+      position === config.positionType.upRight
+      || position === config.positionType.downRight
+    ) {
+      legendX = parentWidth - backgroundWidth - 13;
+    }
 
-  let legendX = 0;
-  let legendY = 0;
-  if (
-    position === config.positionType.downLeft
-    || position === config.positionType.downRight
-  ) {
-    legendY = parentHeight - backgroundHeight - 13;
-  }
-  if (
-    position === config.positionType.upRight
-    || position === config.positionType.downRight
-  ) {
-    legendX = parentWidth - backgroundWidth - 13;
-  }
+    // add background
+    backgroundLayer.append('rect')
+      .style('fill', backgroundColor)
+      .attr('filter', filter)
+      .attr('fill-opacity', 0.85)
+      .attr('stroke', strokeColor)
+      .attr('stroke-width', 2)
+      .attr('width', backgroundWidth)
+      .attr('height', backgroundHeight)
+      .attr('rx', 5)
+      .attr('ry', 5)
+      .attr('x', 8)
+      .attr('y', 5);
 
-  // add background
-  backgroundLayer.append('rect')
-    .style('fill', backgroundColor)
-    .attr('filter', filter)
-    .attr('fill-opacity', 0.85)
-    .attr('stroke', strokeColor)
-    .attr('stroke-width', 2)
-    .attr('width', backgroundWidth)
-    .attr('height', backgroundHeight)
-    .attr('rx', 5)
-    .attr('ry', 5)
-    .attr('x', 8)
-    .attr('y', 5);
-
-  // get legend
-  legend
-    .attr('x', legendX)
-    .attr('y', legendY);
+    // get legend
+    legend
+      .attr('x', legendX)
+      .attr('y', legendY);
+  }, 10);
 }


### PR DESCRIPTION
## Summary
- add `chartXkcd.Combined` for mixing bar and line datasets on one shared axis
- export the new chart type and add an example page entry
- add docs for the combined chart data format and options
- keep legend rendering browser-compatible without changing its public API

Fixes #22

## Checks
- `npm run lint`
- `npm run build`
- `npm run buildUmd`
- `npm run genExample`
- opened the example page locally and confirmed the combined chart renders


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#22: [new chart type]: combined chart](https://oss.issuehunt.io/repos/200573908/issues/22)
---
</details>
<!-- /Issuehunt content-->