### PR TITLE
Add combined bar and line chart type

### DIFF
--- a/docs/10-combined.md
+++ b/docs/10-combined.md
@@ -1,0 +1,39 @@
+---
+title: Combined chart
+---
+
+A combined chart overlays line datasets on top of bar datasets. Use `type: 'line'`
+on datasets that should be rendered as a line; datasets without a `type` render as
+bars.
+
+```js
+const svg = document.querySelector('.combined-chart')
+
+new chartXkcd.Combined(svg, {
+  title: 'Coffee sales and ratings',
+  xLabel: 'Month',
+  yLabel: 'Cups',
+  data: {
+    labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May'],
+    datasets: [{
+      label: 'Cups sold',
+      data: [30, 52, 47, 61, 75],
+    }, {
+      label: 'Rating',
+      type: 'line',
+      data: [22, 30, 42, 52, 60],
+    }],
+  },
+  options: {
+    dataColors: ['#f4a261', '#2a9d8f'],
+    legendPosition: chartXkcd.config.positionType.upLeft,
+  },
+})
+```
+
+## Customize combined chart by defining options
+
+- `yTickCount`: customize tick numbers you want to see on the y axis
+- `dataColors`: array of colors for different datasets
+- `showLegend`: show legend
+- `legendPosition`: specify where you want to put the legend

--- a/examples/example.html
+++ b/examples/example.html
@@ -8,6 +8,7 @@
     <br/>
 
     <div style="width: 400px; height: 300px; display: inline-block;"><svg class="bar-chart"></svg></div>
+    <div style="width: 400px; height: 300px; display: inline-block;"><svg class="combined-chart"></svg></div>
     <div style="width: 400px; height: 300px; display: inline-block;"><svg class="stacked-bar-chart"></svg></div>
     <div style="width: 400px; height: 300px; display: inline-block;"><svg class="pie-chart"></svg></div>
     <div style="width: 400px; height: 300px; display: inline-block;"><svg class="line-chart"></svg></div>

--- a/examples/index.js
+++ b/examples/index.js
@@ -22,6 +22,28 @@ new chartXkcd.Bar(svg, {
   // },
 });
 
+const svgCombined = document.querySelector('.combined-chart');
+new chartXkcd.Combined(svgCombined, {
+  title: 'Coffee sales and ratings',
+  xLabel: 'Month',
+  yLabel: 'Cups',
+  data: {
+    labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May'],
+    datasets: [{
+      label: 'Cups sold',
+      data: [30, 52, 47, 61, 75],
+    }, {
+      label: 'Rating',
+      type: 'line',
+      data: [22, 30, 42, 52, 60],
+    }],
+  },
+  options: {
+    dataColors: ['#f4a261', '#2a9d8f'],
+    legendPosition: chartXkcd.config.positionType.upLeft,
+  },
+});
+
 const svgStackedBar = document.querySelector('.stacked-bar-chart');
 new chartXkcd.StackedBar(svgStackedBar, {
   title: 'Issues and PR Submissions',

--- a/src/Combined.js
+++ b/src/Combined.js
@@ -1,0 +1,294 @@
+import line from 'd3-shape/src/line';
+import { monotoneX } from 'd3-shape/src/curve/monotone';
+import select from 'd3-selection/src/select';
+import mouse from 'd3-selection/src/mouse';
+import scaleBand from 'd3-scale/src/band';
+import scaleLinear from 'd3-scale/src/linear';
+
+import addAxis from './utils/addAxis';
+import addLabels from './utils/addLabels';
+import Tooltip from './components/Tooltip';
+import addLegend from './utils/addLegend';
+import addFont from './utils/addFont';
+import addFilter from './utils/addFilter';
+import colors from './utils/colors';
+import config from './config';
+
+const margin = {
+  top: 50, right: 30, bottom: 50, left: 50,
+};
+
+class Combined {
+  constructor(svg, {
+    title, xLabel, yLabel, data: { labels, datasets }, options,
+  }) {
+    this.options = {
+      unxkcdify: false,
+      yTickCount: 3,
+      legendPosition: config.positionType.upLeft,
+      dataColors: colors,
+      fontFamily: 'xkcd',
+      strokeColor: 'black',
+      backgroundColor: 'white',
+      showLegend: true,
+      ...options,
+    };
+    if (title) {
+      this.title = title;
+      margin.top = 60;
+    }
+    if (xLabel) {
+      this.xLabel = xLabel;
+      margin.bottom = 50;
+    }
+    if (yLabel) {
+      this.yLabel = yLabel;
+      margin.left = 70;
+    }
+    this.data = {
+      labels,
+      datasets,
+    };
+    this.filter = 'url(#xkcdify)';
+    this.fontFamily = this.options.fontFamily || 'xkcd';
+    if (this.options.unxkcdify) {
+      this.filter = null;
+      this.fontFamily = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
+    }
+
+    this.svgEl = select(svg)
+      .style('stroke-width', '3')
+      .style('font-family', this.fontFamily)
+      .style('background', this.options.backgroundColor)
+      .attr('width', svg.parentElement.clientWidth)
+      .attr('height', Math.min((svg.parentElement.clientWidth * 2) / 3, window.innerHeight));
+    this.svgEl.selectAll('*').remove();
+
+    this.chart = this.svgEl.append('g')
+      .attr('transform',
+        `translate(${margin.left},${margin.top})`);
+    this.width = this.svgEl.attr('width') - margin.left - margin.right;
+    this.height = this.svgEl.attr('height') - margin.top - margin.bottom;
+
+    addFont(this.svgEl);
+    addFilter(this.svgEl);
+    this.render();
+  }
+
+  render() {
+    if (this.title) addLabels.title(this.svgEl, this.title, this.options.strokeColor);
+    if (this.xLabel) addLabels.xLabel(this.svgEl, this.xLabel, this.options.strokeColor);
+    if (this.yLabel) addLabels.yLabel(this.svgEl, this.yLabel, this.options.strokeColor);
+
+    const tooltip = new Tooltip({
+      parent: this.svgEl,
+      title: '',
+      items: [],
+      position: { x: 60, y: 60, type: config.positionType.downRight },
+      unxkcdify: this.options.unxkcdify,
+      backgroundColor: this.options.backgroundColor,
+      strokeColor: this.options.strokeColor,
+    });
+
+    const barDatasets = this.data.datasets
+      .filter((dataset) => dataset.type !== 'line');
+    const lineDatasets = this.data.datasets
+      .filter((dataset) => dataset.type === 'line');
+
+    const xScale = scaleBand()
+      .range([0, this.width])
+      .domain(this.data.labels)
+      .padding(0.4);
+
+    const allData = this.data.datasets
+      .reduce((pre, cur) => pre.concat(cur.data), []);
+
+    const yScale = scaleLinear()
+      .domain([0, Math.max(...allData)])
+      .range([this.height, 0]);
+
+    const graphPart = this.chart.append('g')
+      .attr('pointer-events', 'all');
+
+    // axis
+    addAxis.xAxis(graphPart, {
+      xScale,
+      tickCount: 3,
+      moveDown: this.height,
+      fontFamily: this.fontFamily,
+      unxkcdify: this.options.unxkcdify,
+      stroke: this.options.strokeColor,
+    });
+    addAxis.yAxis(graphPart, {
+      yScale,
+      tickCount: this.options.yTickCount || 3,
+      fontFamily: this.fontFamily,
+      unxkcdify: this.options.unxkcdify,
+      stroke: this.options.strokeColor,
+    });
+
+    this.svgEl.selectAll('.domain')
+      .attr('filter', this.filter);
+
+    const barCount = Math.max(barDatasets.length, 1);
+    const barWidth = xScale.bandwidth() / barCount;
+
+    barDatasets.forEach((dataset, datasetIndex) => {
+      graphPart.selectAll(`.xkcd-chart-combined-bar-${datasetIndex}`)
+        .data(dataset.data)
+        .enter()
+        .append('rect')
+        .attr('class', `xkcd-chart-combined-bar-${datasetIndex}`)
+        .attr('x', (d, i) => xScale(this.data.labels[i]) + datasetIndex * barWidth)
+        .attr('width', barWidth)
+        .attr('y', (d) => yScale(d))
+        .attr('height', (d) => this.height - yScale(d))
+        .attr('fill', 'none')
+        .attr('pointer-events', 'all')
+        .attr('stroke', this.options.strokeColor)
+        .attr('stroke-width', 3)
+        .attr('rx', 2)
+        .attr('filter', this.filter)
+        .on('mouseover', (d, i, nodes) => {
+          select(nodes[i]).attr('fill', this.options.dataColors[datasetIndex]);
+          tooltip.show();
+        })
+        .on('mouseout', (d, i, nodes) => {
+          select(nodes[i]).attr('fill', 'none');
+          tooltip.hide();
+        })
+        .on('mousemove', (d, i, nodes) => {
+          this.updateTooltip({
+            tooltip,
+            node: nodes[i],
+            labelIndex: i,
+          });
+        });
+    });
+
+    const theLine = line()
+      .x((d, i) => xScale(this.data.labels[i]) + xScale.bandwidth() / 2)
+      .y((d) => yScale(d))
+      .curve(monotoneX);
+
+    graphPart.selectAll('.xkcd-chart-combined-line')
+      .data(lineDatasets)
+      .enter()
+      .append('path')
+      .attr('class', 'xkcd-chart-combined-line')
+      .attr('d', (d) => theLine(d.data))
+      .attr('fill', 'none')
+      .attr('stroke', (d, i) => this.options.dataColors[barDatasets.length + i])
+      .attr('filter', this.filter);
+
+    const verticalLine = graphPart.append('line')
+      .attr('x1', 30)
+      .attr('y1', 0)
+      .attr('x2', 30)
+      .attr('y2', this.height)
+      .attr('stroke', '#aaa')
+      .attr('stroke-width', 1.5)
+      .attr('stroke-dasharray', '7,7')
+      .style('visibility', 'hidden');
+
+    const circles = lineDatasets.map((dataset, i) => graphPart
+      .append('circle')
+      .style('stroke', this.options.dataColors[barDatasets.length + i])
+      .style('fill', this.options.dataColors[barDatasets.length + i])
+      .attr('r', 3.5)
+      .style('visibility', 'hidden'));
+
+    graphPart.append('rect')
+      .attr('width', this.width)
+      .attr('height', this.height)
+      .attr('fill', 'none')
+      .on('mouseover', () => {
+        circles.forEach((circle) => circle.style('visibility', 'visible'));
+        verticalLine.style('visibility', 'visible');
+        tooltip.show();
+      })
+      .on('mouseout', () => {
+        circles.forEach((circle) => circle.style('visibility', 'hidden'));
+        verticalLine.style('visibility', 'hidden');
+        tooltip.hide();
+      })
+      .on('mousemove', (d, i, nodes) => {
+        const labelXs = this.data.labels.map(
+          (label) => xScale(label) + xScale.bandwidth() / 2 + margin.left,
+        );
+        const mouseLabelDistances = labelXs.map(
+          (labelX) => Math.abs(labelX - mouse(nodes[i])[0] - margin.left),
+        );
+        const mostNearLabelIndex = mouseLabelDistances.indexOf(Math.min(...mouseLabelDistances));
+
+        verticalLine
+          .attr('x1', xScale(this.data.labels[mostNearLabelIndex]) + xScale.bandwidth() / 2)
+          .attr('x2', xScale(this.data.labels[mostNearLabelIndex]) + xScale.bandwidth() / 2);
+
+        lineDatasets.forEach((dataset, j) => {
+          circles[j]
+            .style('visibility', 'visible')
+            .attr('cx', xScale(this.data.labels[mostNearLabelIndex]) + xScale.bandwidth() / 2)
+            .attr('cy', yScale(dataset.data[mostNearLabelIndex]));
+        });
+
+        this.updateTooltip({
+          tooltip,
+          node: nodes[i],
+          labelIndex: mostNearLabelIndex,
+        });
+      });
+
+    if (this.options.showLegend) {
+      const legendItems = this.data.datasets
+        .map((dataset, i) => ({
+          color: this.options.dataColors[i],
+          text: dataset.label,
+        }));
+
+      addLegend(graphPart, {
+        items: legendItems,
+        position: this.options.legendPosition,
+        unxkcdify: this.options.unxkcdify,
+        parentWidth: this.width,
+        parentHeight: this.height,
+        backgroundColor: this.options.backgroundColor,
+        strokeColor: this.options.strokeColor,
+      });
+    }
+  }
+
+  updateTooltip({ tooltip, node, labelIndex }) {
+    const tipX = mouse(node)[0] + margin.left + 10;
+    const tipY = mouse(node)[1] + margin.top + 10;
+
+    const tooltipItems = this.data.datasets.map((dataset, i) => ({
+      color: this.options.dataColors[i],
+      text: `${dataset.label || ''}: ${dataset.data[labelIndex]}`,
+    }));
+
+    let tooltipPositionType = config.positionType.downRight;
+    if (tipX > this.width / 2 && tipY < this.height / 2) {
+      tooltipPositionType = config.positionType.downLeft;
+    } else if (tipX > this.width / 2 && tipY > this.height / 2) {
+      tooltipPositionType = config.positionType.upLeft;
+    } else if (tipX < this.width / 2 && tipY > this.height / 2) {
+      tooltipPositionType = config.positionType.upRight;
+    }
+
+    tooltip.update({
+      title: this.data.labels[labelIndex],
+      items: tooltipItems,
+      position: {
+        x: tipX,
+        y: tipY,
+        type: tooltipPositionType,
+      },
+    });
+  }
+
+  update() {
+  }
+}
+
+export default Combined;

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,11 @@ import Bar from './Bar';
 import StackedBar from './StackedBar';
 import Pie from './Pie';
 import Line from './Line';
+import Combined from './Combined';
 import XY from './XY';
 import Radar from './Radar';
 import config from './config';
 
 module.exports = {
-  config, Bar, StackedBar, Pie, Line, XY, Radar,
+  config, Bar, StackedBar, Pie, Line, Combined, XY, Radar,
 };

--- a/src/utils/addLegend.js
+++ b/src/utils/addLegend.js
@@ -29,7 +29,7 @@ export default async function addLegend(parent, {
   });
 
   // wait for textLayer to render, a bit wired
-  await new Promise(resolve => setTimeout(resolve, 10))
+  await new Promise((resolve) => setTimeout(resolve, 10));
 
   const bbox = textLayer.node().getBBox();
   const backgroundWidth = bbox.width + 15;


### PR DESCRIPTION
Adds a `Combined` chart type for rendering bar datasets with overlaid line datasets on the same categorical x-axis.

What changed:
- added `chartXkcd.Combined`
- rendered datasets with `type: 'line'` as lines and other datasets as bars
- added legend and tooltip support for mixed datasets
- added docs and an example

Checks run:
- `npm ci`
- `npm run lint`
- `npm run build`
- `npm run buildUmd`
- `npm run genExample`
- `git diff --check`

Closes #22